### PR TITLE
Add no-console to ESLint

### DIFF
--- a/dashboard/.eslintrc.js
+++ b/dashboard/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'error',
         '@typescript-eslint/no-unused-vars': 'error',
-        'no-console': "on",
+        'no-console': 'error',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/naming-convention': [


### PR DESCRIPTION
To prevent bad code from being committed or pushed, I've disabled the ability to use the console in client-side code for production builds.