### PR TITLE
add finishing ' to the end of jq examples

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -252,7 +252,7 @@ Prerequisites:
         aws ecr create-repository --repository-name $MODEL_REPO
 
         # If the repositories are created using the default registry
-        read ENDPOINT < <(echo $(aws ecr get-authorization-token | jq '.authorizationData[0].proxyEndpoint))
+        read ENDPOINT < <(echo $(aws ecr get-authorization-token | jq '.authorizationData[0].proxyEndpoint'))
         ```
 
 
@@ -267,7 +267,7 @@ Prerequisites:
     aws ecr create-repository --registry-id $REGISTRY_ID --repository-name $MODEL_REPO
 
     # If the repostiroies are created use a different registry id from the default
-    read ENDPOINT < <(echo $(aws ecr get-authorization-token --regsitry-ids $REGISTRY_ID | jq '.authorizationData[0].proxyEndpoint))
+    read ENDPOINT < <(echo $(aws ecr get-authorization-token --regsitry-ids $REGISTRY_ID | jq '.authorizationData[0].proxyEndpoint'))
     ```
 
 2. Get ECR registry password info


### PR DESCRIPTION
the missing ' at the end of js makes the example failed to be executed.