### PR TITLE
lint: fix the problem that golangci-lint does not support go 1.18

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,8 @@ run:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
 
+  go: '1.17'
+
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   format: colored-line-number


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/issues/2649