### PR TITLE
Fix typo and outdated yatai docs

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -223,9 +223,11 @@ Prerequisites:
     ```bash
     USER_PASSWORD=secret99
     USER_NAME=admin
+    DB_NAME=yatai
     INSTANCE_IDENTIFIER=yatai-postgres
 
     aws rds create-db-instance \
+        --db-name $DB_NAME \
         --db-instance-identifier $INSTANCE_IDENTIFIER \
         --db-instance-class db.t3.micro \
         --engine postgres \

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -239,6 +239,7 @@ Prerequisites:
         --from-literal=password=$USER_PASSWORD \
         -n yatai-system
     ```
+    Make sure your RDS db allows has a security group that will allow Yatai to access it.
 
 2. Get the RDS instance’s endpoint and port information
 


### PR DESCRIPTION
Fixing a few of the things I ran into going through this guide
1. Typo on externalS3 SecretKey property
2. Create secrets in yatai-system namespace (Can't seem to find secrets otherwise)
3. Use secret for externalPostgres
4. Create yatai-system namespace ahead of time
5. Add necessary matching DB name
6. Add reminder to set RDS security group