### PR TITLE
feat: Added optional value in helm chart to mount host timezone file

### DIFF
--- a/helm/yatai/templates/deployment.yaml
+++ b/helm/yatai/templates/deployment.yaml
@@ -93,9 +93,11 @@ spec:
             - mountPath: /conf
               name: config
               readOnly: true
+            {{- if .Values.enableHostTimeZone }}
             - mountPath: /etc/localtime
               name: host-timezone
               readOnly: true
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -109,10 +111,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.enableHostTimeZone }}
         - hostPath:
             path: /etc/localtime
             type: ""
           name: host-timezone
+        {{- end }}
         - name: config
           secret:
             secretName: {{ include "yatai.fullname" . }}

--- a/helm/yatai/values.yaml
+++ b/helm/yatai/values.yaml
@@ -104,3 +104,4 @@ s3:
   secretKeyExistingSecretName: ''
   secretKeyExistingSecretKey: 'secret_key'
 
+enableHostTimeZone: false 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new optional field in Helm Chart called _enableHostTimeZone_ that lets you mount the timezone file from Host onto the Yatai Deployment containers. 

Reason for this optional field:
- It is not advised to mount Host volumes directly onto the containers as there are security risks involved. 
- Certain managed Kubernetes providers prohibit users from mounting Host Volumes, that will prevent users from running the application itself. 

