### PR TITLE
feat: update HPA api to v2 for K8s 1.24+

### DIFF
--- a/api-server/services/deployment.go
+++ b/api-server/services/deployment.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	appstypev1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2"
+	v2 "k8s.io/client-go/kubernetes/typed/autoscaling/v2"
 	batchtypev1 "k8s.io/client-go/kubernetes/typed/batch/v1"
 	batchtypev1beta "k8s.io/client-go/kubernetes/typed/batch/v1beta1"
 	apitypev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -379,13 +379,13 @@ func (s *deploymentService) GetKubeDeploymentsCli(ctx context.Context, d *models
 	return deploymentsCli, nil
 }
 
-func (s *deploymentService) GetKubeHPAsCli(ctx context.Context, d *models.Deployment) (v2beta2.HorizontalPodAutoscalerInterface, error) {
+func (s *deploymentService) GetKubeHPAsCli(ctx context.Context, d *models.Deployment) (v2.HorizontalPodAutoscalerInterface, error) {
 	cliset, _, err := s.GetKubeCliSet(ctx, d)
 	if err != nil {
 		return nil, errors.Wrap(err, "get k8s cliset")
 	}
 	ns := s.GetKubeNamespace(d)
-	hpaCli := cliset.AutoscalingV2beta2().HorizontalPodAutoscalers(ns)
+	hpaCli := cliset.AutoscalingV2().HorizontalPodAutoscalers(ns)
 	return hpaCli, nil
 }
 


### PR DESCRIPTION
Fixes: https://github.com/bentoml/Yatai/issues/449

This PR updates the HPA version used by the backend from `v2beta2` to `v2` to support newer versions of Kubernetes. Note: this does mean that Kubernetes `v1.23.0` will be the new minimum supported version. Since Kubernetes `v1.27.0` was recently released I believe this shouldn't be a large problem.

Related `yatai-deployment` PR: https://github.com/bentoml/yatai-deployment/pull/113