### PR TITLE
feat(helm): update HPA to autoscaling/v2

### DIFF
--- a/helm/yatai/templates/hpa.yaml
+++ b/helm/yatai/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "yatai.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Related to: https://github.com/bentoml/Yatai/issues/449

This PR updates the HPA API version in the helm chart from `autoscaling/v2beta1` to `autoscaling/v2`. This means that people using the HPA will need to be using Kubernetes at least `v1.23.0`. Since Kubernetes v1.27.0 was recently released I believe this shouldn't be a large problem.