### PR TITLE
Fix memory resource unit for CRD deployment example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ metadata:
     name: iris-classifier
     namespace: yatai
 spec:
-    bentoTag: iris_classifier:3oevmqfvnkvwvuqj
+    bentoTag: iris_classifier:3oevmqfvnkvwvuqj  # check the tag by `bentoml list iris_classifier`
 ---
 apiVersion: serving.yatai.ai/v2alpha1
 kind: BentoDeployment
@@ -179,10 +179,10 @@ spec:
     resources:
         limits:
             cpu: "500m"
-            memory: "512m"
+            memory: "512Mi"
         requests:
             cpu: "250m"
-            memory: "128m"
+            memory: "128Mi"
     autoscaling:
         maxReplicas: 10
         minReplicas: 2
@@ -194,7 +194,7 @@ spec:
                   memory: "1Gi"
               requests:
                   cpu: "500m"
-                  memory: "512m"
+                  memory: "512Mi"
           autoscaling:
               maxReplicas: 4
               minReplicas: 1


### PR DESCRIPTION
## AS-IS
```yaml
    resources:
        limits:
            cpu: "500m"
            memory: "512m"
        requests:
            cpu: "250m"
            memory: "128m"
```
`512m` for memory means 0.512 bytes. It doesn't look intended for this example.

> Pay attention to the case of the suffixes. If you request 400m of memory, this is a request for 0.4 bytes. Someone who types that probably meant to ask for 400 mebibytes (400Mi) or 400 megabytes (400M).

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory

## TO-BE
```yaml
    resources:
        limits:
            cpu: "500m"
            memory: "512Mi"
        requests:
            cpu: "250m"
            memory: "128Mi"
```
The memory resource unit for mebibytes is `Mi`. (megabytes is `M`)
