### PR TITLE
feat(helm-chart): add commonLabels capability

### DIFF
--- a/helm/yatai/templates/_helpers.tpl
+++ b/helm/yatai/templates/_helpers.tpl
@@ -45,6 +45,7 @@ helm.sh/chart: {{ include "yatai.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- toYaml .Values.commonLabels | nindent 0 }}
 {{- end }}
 
 {{/*

--- a/helm/yatai/values.yaml
+++ b/helm/yatai/values.yaml
@@ -76,6 +76,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+commonLabels: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
I would like to suggest the establishment of common labels. The majority of helm charts use this implementation mainly for identification constraints in an organization.

Related issue:
- https://github.com/bentoml/Yatai/issues/486