### PR TITLE
Fix(helm-chart): use a range finction instead of toYaml for commonLabels

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,8 @@ on:
       - main
       - v1.0.0
   pull_request:
-    branches:
-      - main
-      - v1.0.0
+    types:
+      - unlocked
 
 jobs:
   typos-check:

--- a/helm/yatai/templates/_helpers.tpl
+++ b/helm/yatai/templates/_helpers.tpl
@@ -45,7 +45,9 @@ helm.sh/chart: {{ include "yatai.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- toYaml .Values.commonLabels | nindent 0 }}
+{{- range $key, $val := .Values.commonLabels }}
+{{ $key }}: {{ $val }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Original Issue

From my previous [Merged Pull Request](https://github.com/bentoml/Yatai/pull/487), I saw the `helm lint` check failed.

I didn't test it properly and I apologize.

## Proposal

- [Helm Chart] I proposed a quick fix for `commonLabels` to use range instead of `toYaml`. Because if you don't provide `commonLabels`, the chart will fail.
- [GitHub Action] An improvement for your CI to run the check

## Not Totally Aware of my skilset on Github Action

I didn't touch GitHub Action since a long time, so, I'm not 100% sure of it. But, it should be important to have this check before the merge 😇 

Any comments/changes are welcome 😃 