### PR TITLE
refactor(setup): migrate local PostgreSQL client containers from Bitnami to official Alpine image

### DIFF
--- a/docs/source/installation/yatai.rst
+++ b/docs/source/installation/yatai.rst
@@ -123,7 +123,7 @@ Installation Steps
           kubectl -n yatai-system delete pod postgresql-ha-client 2> /dev/null || true; \
           kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
               --namespace yatai-system \
-              --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+              --image postgres:14.4-alpine \
               --env="PGPASSWORD=$PG_PASSWORD" \
               --command -- psql -h $PG_HOST -p $PG_PORT -U $PG_USER -d $PG_DATABASE -c "select 1"
 
@@ -192,7 +192,7 @@ Installation Steps
           kubectl -n yatai-system delete pod postgresql-ha-client 2> /dev/null || true; \
           kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
               --namespace yatai-system \
-              --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+              --image postgres:14.4-alpine \
               --env="PGPASSWORD=$PG_PASSWORD" \
               --command -- psql -h postgresql-ha-pgpool -p 5432 -U postgres -d postgres -c "select 1"
 
@@ -216,7 +216,7 @@ Installation Steps
           kubectl -n yatai-system delete pod postgresql-ha-client 2> /dev/null || true; \
           kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
               --namespace yatai-system \
-              --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+              --image postgres:14.4-alpine \
               --env="PGPASSWORD=$PG_PASSWORD" \
               --command -- psql -h postgresql-ha-pgpool -p 5432 -U postgres -d postgres -c "create database $PG_DATABASE"
 
@@ -238,7 +238,7 @@ You can create a connection test by running the following command and inspecting
   kubectl -n yatai-system delete pod postgresql-ha-client 2> /dev/null || true; \
   kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
       --namespace yatai-system \
-      --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+      --image postgres:14.4-alpine \
       --env="PGPASSWORD=$PG_PASSWORD" \
       --command -- psql -h $PG_HOST -p $PG_PORT -U $PG_USER -d $PG_DATABASE -c "select 1"
 

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -21,7 +21,7 @@ yetone/grafana:8.2.0
 grafana/promtail:2.4.1
 busybox
 minio/minio:RELEASE.2021-10-06T23-36-31Z
-bitnami/postgresql-repmgr:11.14.0-debian-10-r12
+postgres:11.14-alpine
 )
 
 for image in "${images[@]}"; do

--- a/scripts/quick-install-yatai.sh
+++ b/scripts/quick-install-yatai.sh
@@ -117,7 +117,7 @@ kubectl -n ${namespace} delete pod postgresql-ha-client 2>/dev/null || true
 
 kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
   --namespace ${namespace} \
-  --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+  --image postgres:14.4-alpine \
   --env="PGPASSWORD=$PG_PASSWORD" \
   --command -- psql -h postgresql-ha-pgpool -p 5432 -U postgres -d postgres -c "SELECT 1"
 
@@ -127,7 +127,7 @@ echo "🧐 checking if PostgreSQL database ${PG_DATABASE} exists..."
 kubectl -n ${namespace} delete pod postgresql-ha-client 2>/dev/null || true
 if ! kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
   --namespace ${namespace} \
-  --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+  --image postgres:14.4-alpine \
   --env="PGPASSWORD=$PG_PASSWORD" \
   --command -- psql -h postgresql-ha-pgpool -p 5432 -U postgres -d ${PG_DATABASE} -c "SELECT 1" >/dev/null 2>&1; then
 
@@ -137,7 +137,7 @@ if ! kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
 
   kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
     --namespace ${namespace} \
-    --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+    --image postgres:14.4-alpine \
     --env="PGPASSWORD=$PG_PASSWORD" \
     --command -- psql -h postgresql-ha-pgpool -p 5432 -U postgres -d postgres -c "CREATE DATABASE $PG_DATABASE"
 
@@ -151,7 +151,7 @@ kubectl -n ${namespace} delete pod postgresql-ha-client 2>/dev/null || true
 
 kubectl run postgresql-ha-client --rm --tty -i --restart='Never' \
   --namespace ${namespace} \
-  --image docker.io/bitnami/postgresql-repmgr:14.4.0-debian-11-r13 \
+  --image postgres:14.4-alpine \
   --env="PGPASSWORD=$PG_PASSWORD" \
   --command -- psql -h $PG_HOST -p $PG_PORT -U $PG_USER -d $PG_DATABASE -c "select 1"
 


### PR DESCRIPTION
## Problem

The Yatai quick-start script, cache builder, and official docs currently rely directly on the bitnami/postgresql-repmgr Docker image for running local database check/initialization tasks via kubectl run.

Recently, Bitnami has placed strict rate limits and registry access restrictions on their images. This causes frequent pull access denied errors, breaking the developer onboarding experience for users running the "Quick Tour" or following the official guide.

<b> Resolves / Closes: #513 </b>


## Solution

Since these local initializations only require a raw psql client CLI (and do not run replication managers or database servers in the client pod), we can drop the heavy, restricted Bitnami image in favor of the lightweight, unrestricted, and official community Alpine image.

This PR replaces bitnami/postgresql-repmgr with postgres:alpine across the following files:


- Quick-start script: `scripts/quick-install-yatai.sh`

- Official documentation: `docs/source/installation/yatai.rst`

- Image caching script: `scripts/build-images.sh`